### PR TITLE
fix: room 内で退出ボタンが表示出来ない不具合を解消する

### DIFF
--- a/ovice-helper/contentScript/main.js
+++ b/ovice-helper/contentScript/main.js
@@ -7,7 +7,17 @@ setInterval(() => {
     ) {
         main();
     }
+    if (
+        document.querySelector('#MenuBar').parentNode.querySelectorAll('._alignItems-stretch').length > 0 &&
+        document.querySelector('#MenuBar').parentNode.querySelector('._alignItems-stretch').style.display !== 'contents'
+    ) {
+        showRoomExitButton();
+    }
 }, 2000);
+
+function showRoomExitButton() {
+    document.querySelector('#MenuBar').parentNode.querySelector('._alignItems-stretch').style.cssText = 'display: contents;';
+}
 
 function main() {
     const menuBarRoot = document.querySelector('#MenuBar');

--- a/ovice-helper/contentScript/main.js
+++ b/ovice-helper/contentScript/main.js
@@ -29,7 +29,6 @@ function main() {
             e.remove();
         });
         menuBar.style.cssText = 'display:flex;align-items:center;overflow:visible';
-        reactionsMenu.classList.add('s-selector');
     };
 
     const insertBorder = () => {


### PR DESCRIPTION
### 対応内容
Room 用UIに切り替わったことを検知したタイミングで、`div._alignItems-stretch._display-flex._flexDirection-column._flexBasis-auto._boxSizing-border-box._position-relative._minHeight-0px._minWidth-0px._flexShrink-0._opacity-1._transition-977756578` に対して `display: contents;` を付与する。

![実装サンプル](https://github.com/snst-lab/chrome-extensions/assets/57829584/319bd65d-592c-4440-a619-e17e7e6ac69f)

### 備考
画面の横幅が 850px 以下の場合は、退出ボタンが MenuBar に統合されるのですが、この対応では対応を行っていません。